### PR TITLE
trigger bumping version of geohub repo

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,3 +39,16 @@ jobs:
         file: Dockerfile
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+
+      # This job is going to trigger an event named `bump-pipeline-version`
+      # on undp-data/geohub repo in order to make a PR to bump version of data pipeline to AKS
+    - name: dispatch event to GeoHub repo to create release PR
+      uses: peter-evans/repository-dispatch@v1
+      if: startsWith(github.ref, 'refs/tags/v')
+      with:
+        repository: undp-data/geohub
+        # https://www.eliostruyf.com/dispatch-github-action-fine-grained-personal-access-token/
+        # need scopes of metadata and contents
+        # created `geohub-data-pipeline-bump` token which will be expired on 17 November 2024
+        token: ${{ secrets.GEOHUB_REPO_DISPATCH_TOKEN }}
+        event-type: bump-stacpipeline-version


### PR DESCRIPTION
I created personal token to dispatch event in geohub repo. and registered it as GEOHUB_REPO_DISPATCH_TOKEN secret in this repo.

don't merge it before merging this PR https://github.com/UNDP-Data/geohub/pull/3459 in geohub

related to https://github.com/UNDP-Data/geohub/issues/3052