### PR TITLE
Update geo-undpstac-pipeline-bump token

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,6 +49,6 @@ jobs:
         repository: undp-data/geohub
         # https://www.eliostruyf.com/dispatch-github-action-fine-grained-personal-access-token/
         # need scopes of metadata and contents
-        # created `geohub-data-pipeline-bump` token which will be expired on 17 November 2024
+        # created `geo-undpstac-pipeline-bump` token which will be expired on 31 May 2026
         token: ${{ secrets.GEOHUB_REPO_DISPATCH_TOKEN }}
         event-type: bump-stacpipeline-version


### PR DESCRIPTION
geo-undpstac-pipeline-bump token was expired, regenerated token to extend for another a year

