### PR TITLE
fix: expose client id and secret as environmental variable for EOG authentication

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -5,5 +5,7 @@ AZURE_SERVICE_BUS_CONNECTION_STRING=
 AZURE_SERVICE_BUS_QUEUE_NAME=
 # login user ID and password
 # see https://eogdata.mines.edu/products/register/
+EOG_CLIENT_ID=
+EOG_CLIENT_SECRET=
 EOG_USER=
 EOG_PASSWORD=

--- a/undpstac_pipeline/acore.py
+++ b/undpstac_pipeline/acore.py
@@ -410,9 +410,11 @@ async def process_nighttime_data(date: datetime.date = None,
 
     try:
         ################### get access token from EOG  ########################
+        eog_client_id = os.environ.get('EOG_CLIENT_ID')
+        eog_client_secret = os.environ.get('EOG_CLIENT_SECRET')
         eog_user = os.environ.get('EOG_USER')
         eog_password = os.environ.get('EOG_PASSWORD')
-        access_token = await get_access_token(eog_user, eog_password)
+        access_token = await get_access_token(eog_client_id,eog_client_secret, eog_user, eog_password)
         logger.debug(f"access_token: {access_token}")
 
         remote_dnb_files = get_dnb_files(date=date,file_type=file_type, access_token=access_token)

--- a/undpstac_pipeline/colorado_eog.py
+++ b/undpstac_pipeline/colorado_eog.py
@@ -61,15 +61,13 @@ def get_dnb_files(date=None, file_type=None, access_token=None) -> Dict[Literal[
     }
 
 
-async def get_access_token(username, password):
+async def get_access_token(client_id, client_secret, username, password):
     """
     Fetch an access token using username and password from EOG.
     See how to fetch access token using username and password from EOG here.
     https://eogdata.mines.edu/products/register/
     """
-    token_url = 'https://eogauth.mines.edu/auth/realms/master/protocol/openid-connect/token'
-    client_id = 'eogdata_oidc'
-    client_secret = '2677ad81-521b-4869-8480-6d05b9e57d48'
+    token_url = 'https://eogauth-new.mines.edu/realms/eog/protocol/openid-connect/token'
 
     async with aiohttp.ClientSession() as session:
         payload = {


### PR DESCRIPTION
The way of authenticating to EOG server was changed since June.

https://eogdata.mines.edu/products/register/

According to this website documentation, I changed token_url, and now expose client id and secret as environmental variables.

I already sent an email to eog@mines.edu to request client ID and secret for UNDP GeoHub. Hope they will give us soon.